### PR TITLE
submit list of messages for parsing, copy ECU flags

### DIFF
--- a/obd/obd.py
+++ b/obd/obd.py
@@ -359,8 +359,8 @@ class OBD(object):
             # and how many bytes the command response is. then construct a response
             # message.
             # @brendan-w wrote this newer version
-            master = messages #[0] # the message that contains our response
-            print "master.data: " + master.data.decode()
+            master = messages[0] # the message that contains our response
+            print("master.data: " + master.data.decode())
             mode = master.data.pop(0) # the mode byte (ie, for mode 01 this would be 0x41)
             
             cmds_by_pid = { cmd.pid:cmd for cmd in cmds }
@@ -369,8 +369,8 @@ class OBD(object):
             while len(master.data) > 0:
                 pid = master.data[0]
                 cmd = cmds_by_pid.get(pid, None)
-                print "pid: " + str(pid)
-                print "cmd: " + str(cmd.pid)
+                print("pid: " + str(pid))
+                print("cmd: " + str(cmd.pid))
 
                 # if the PID we pulled out wasn't one of the commands we were given
                 # then something is very wrong. Abort, and proceed with whatever
@@ -380,7 +380,7 @@ class OBD(object):
                     break
     
                 l = cmd.bytes - 1 # this figure INCLUDES the PID byte
-                print "l: " + str(l)
+                print("l: " + str(l))
 
                 # if the message doesn't have enough data left in it to fulfill a
                 # PID, then abort, and proceed with whatever we've decoded so far
@@ -394,16 +394,17 @@ class OBD(object):
                     print "frame[" + str(p) + "]: " + str(u.raw)
                     p += 1
                 message = Message(master.frames) # copy of the original lines
+                message.ecu = master.ecu
                 message.data = master.data[:l]
-                print "post-chop: " + message.data.decode()
+                print("post-chop: " + message.data.decode())
                 message.data.insert(0, mode) # prepend the original mode byte
-                print "post-insert: " + message.data.decode()
+                print("post-insert: " + message.data.decode())
                 
                 # decode the message
-                responses[cmd] = cmd(message)
+                responses[cmd] = cmd([message])
             
                 # remove what we just read
                 master.data = master.data[l:]
                 
-            print responses
+            print(responses)
             #return cmd(messages) # compute a response object


### PR DESCRIPTION
My mistakes:
- `OBDCommands` expect lists of messages (in case messages from multiple ECUs are received)
- messages also have some ECU marking flags that needed to be copied over

Made some minor tweaks to `print` statements to make them python 2+3 compatible. Briefly tested it.
